### PR TITLE
Inf debug

### DIFF
--- a/R/singleESMcalibration.R
+++ b/R/singleESMcalibration.R
@@ -309,7 +309,10 @@ make_minimize_function <- function(hector_cores, esm_data, normalize, param, cmi
 
             }
 
-
+        # Replace Inf values a large number
+        intermediateRslt %>%
+            dplyr::mutate(value = if_else(is.infinite(value), 8675309, value)) ->
+            intermediateRslt
         # Clean up partallel clusters.
         doParallel::stopImplicitCluster()
 


### PR DESCRIPTION
The single ESM function was originally set up to only replace `NA` values with a large arbitrary number but when the -log mesa is used to calibrate to the CMIP range  sometimes we can get `Inf` values which causes problems for `optim`. This change replaces the `Inf` values with the same arbitrary number number. 